### PR TITLE
MUP-16811: updated asynchttpclient version, made 'prints' a managed dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,9 @@ libraryDependencies ++= {
       exclude("io.reactivex", "rxnetty")
       exclude("com.netflix.archaius", "archaius-core"), // TODO make sure this is safe
     "com.meetup" %% "scala-logger" % "0.2.22",
-    "org.asynchttpclient" % "async-http-client" % "2.0.26",
+    "org.asynchttpclient" % "async-http-client" % "2.0.37",
     "me.lessis" %% "base64" % "0.2.0",
+    "me.lessis" %% "prints" % "0.1.0",
 
     //test
     "org.mockito" % "mockito-core" % "2.8.47" % "test"


### PR DESCRIPTION
* AsyncHttpClient update fixes a bug with IllegalAccessError when there are multiple class loaders (see https://github.com/AsyncHttpClient/async-http-client/issues/1382)
* 'prints' library was made a managed dependency, so that it's included in the library .jar file.